### PR TITLE
Make `edxapp` user a sudoer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install base packages:
 
 Create unprivileged user which will run the web applications:
 
-    sudo adduser edxapp
+    sudo adduser edxapp sudo
     sudo su edxapp
 
 Create folder in which everything will be installed:


### PR DESCRIPTION
The current documentation doesn't allow the `edxapp` user to perform `sudo` commands.