### PR TITLE
Removed duplicates of `KEY_PREFIX`

### DIFF
--- a/config/cms/cms.env.json
+++ b/config/cms/cms.env.json
@@ -22,14 +22,12 @@
       "VERSION": "1",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "general": {
       "KEY_PREFIX":  "general",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "mongo_metadata_inheritance": {
@@ -37,21 +35,18 @@
       "TIMEOUT": 300,
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "staticfiles": {
       "KEY_PREFIX": "staticfiles_general",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "configuration": {
       "KEY_PREFIX": "configuration",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "celery": {
@@ -59,7 +54,6 @@
       "TIMEOUT": "7200",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "course_structure_cache": {
@@ -68,7 +62,6 @@
       "TIMEOUT": "7200",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     }
   }

--- a/config/lms/lms.env.json
+++ b/config/lms/lms.env.json
@@ -22,14 +22,12 @@
       "VERSION": "1",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "general": {
       "KEY_PREFIX":  "general",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "mongo_metadata_inheritance": {
@@ -37,21 +35,18 @@
       "TIMEOUT": 300,
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "staticfiles": {
       "KEY_PREFIX": "staticfiles_general",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "configuration": {
       "KEY_PREFIX": "configuration",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "celery": {
@@ -59,7 +54,6 @@
       "TIMEOUT": "7200",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     },
     "course_structure_cache": {
@@ -68,7 +62,6 @@
       "TIMEOUT": "7200",
       "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
       "KEY_FUNCTION": "util.memcache.safe_key",
-      "KEY_PREFIX": "default",
       "LOCATION": "localhost:11211"
     }
   }


### PR DESCRIPTION
Noticed this in my editor when creating my custom install. Not tested but I'm presuming there shouldn't be duplicates within an object.